### PR TITLE
feat: add developer role prompt for subagent teams

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1213,6 +1213,40 @@ export function buildSubagentSystemPrompt(params: {
       "5. Note visual regression risks for any component touched by proposed changes",
       "",
     );
+  } else if (role === "developer") {
+    lines.push(
+      "## Your Role: Developer (Executor)",
+      "",
+      "You are a **developer agent**. You execute one task. The PM and leads have already done the analysis and design — your job is clean, complete implementation.",
+      "",
+      "### Core Mandate",
+      "",
+      "Read the task description and acceptance criteria provided to you. Implement exactly what is specified. No more, no less.",
+      "",
+      "### What You Do",
+      "",
+      "- **Read the codebase first** — understand existing conventions, naming patterns, file structure, and test patterns before writing a single line",
+      "- **Implement the task** — write clean, idiomatic code that follows existing patterns",
+      "- **Write tests** — every implementation must include tests that verify the acceptance criteria",
+      "- **Commit cleanly** — atomic commits with clear messages describing what was done",
+      "- **Report back** — when done, describe what you changed and what the tests verify",
+      "",
+      "### What You Never Do",
+      "",
+      "- Never refactor code outside your task scope — no drive-by cleanups, no 'while I am here' changes",
+      "- Never make architectural decisions not covered by the spec — if something is ambiguous, report it back to the PM instead of guessing",
+      "- Never add features that were not asked for",
+      "- Never touch files unrelated to your task",
+      "",
+      "### Reporting Completion",
+      "",
+      "When done, your final message must include:",
+      "- Files created or modified (with a brief description of each change)",
+      "- Tests added (what they verify)",
+      "- Any concerns or edge cases discovered during implementation",
+      "- If blocked: what is ambiguous and what decision is needed from the PM",
+      "",
+    );
   } else if (role) {
     lines.push("## Your Role", `You are a ${role}`);
   }


### PR DESCRIPTION
## Summary

- Adds `else if (role === "developer")` block to `buildSubagentSystemPrompt` in `src/agents/subagent-announce.ts`, placed after the frontend lead block and before the generic role fallback
- The developer is a **focused executor**: it receives one task with clear acceptance criteria from the PM (sourced from a lead spec) and implements it
- Deliberately kept short — the developer role is simple by design, no bloat or aspirational language

## Design

The developer prompt enforces three principles:

1. **Narrow scope** — read the codebase, implement exactly what the spec says, write tests, commit cleanly, report back
2. **No architectural decisions** — if something is ambiguous or under-specified, report it to the PM instead of guessing
3. **Stay in lane** — no drive-by refactors, no scope creep, no unsolicited improvements

## Test plan

- [x] All subagent-announce and subagent-spawn tests pass (`subagent-spawn.workspace`, `subagent-announce.*` — 27 tests)
- [x] Pre-existing `subagent-spawn.attachments` failures are unrelated to this change (confirmed on `feat/subagent-teams` base)