### PR TITLE
feat: session-aware webhook dispatch

### DIFF
--- a/src/gateway/branch-registry.test.ts
+++ b/src/gateway/branch-registry.test.ts
@@ -1,0 +1,184 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  getBranchEntry,
+  listBranches,
+  registerBranch,
+  resolveBranchRegistryPath,
+  type BranchRegistryEntry,
+  unregisterBranch,
+} from "./branch-registry.js";
+
+describe("branch-registry", () => {
+  let registryPath: string;
+
+  beforeEach(() => {
+    registryPath = path.join(
+      os.tmpdir(),
+      `openclaw-test-registry-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    process.env.OPENCLAW_BRANCH_REGISTRY_PATH = registryPath;
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCLAW_BRANCH_REGISTRY_PATH;
+    try {
+      fs.unlinkSync(registryPath);
+    } catch {
+      // ignore — file may not exist
+    }
+  });
+
+  const exampleEntry: BranchRegistryEntry = {
+    sessionKey: "agent:main:subagent:abc123",
+    prNumber: 56,
+    repo: "yoiksoft/yoik.me",
+    createdAt: "2026-03-17T18:04:00Z",
+    status: "watching",
+  };
+
+  describe("resolveBranchRegistryPath", () => {
+    test("returns env var override as resolved path", () => {
+      const customPath = "/tmp/custom-registry.json";
+      expect(resolveBranchRegistryPath({ OPENCLAW_BRANCH_REGISTRY_PATH: customPath })).toBe(
+        path.resolve(customPath),
+      );
+    });
+
+    test("uses temp path in test environment", () => {
+      const p = resolveBranchRegistryPath({ VITEST: "1" });
+      expect(p).toContain("openclaw-test-branch-registry");
+    });
+  });
+
+  describe("registerBranch", () => {
+    test("writes entry to registry file", () => {
+      registerBranch("feature/ratings-favourites", exampleEntry);
+      const raw = JSON.parse(fs.readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+      expect(raw["feature/ratings-favourites"]).toEqual(exampleEntry);
+    });
+
+    test("overwrites an existing entry for the same branch", () => {
+      registerBranch("feature/ratings-favourites", exampleEntry);
+      const updated: BranchRegistryEntry = { ...exampleEntry, sessionKey: "session:new" };
+      registerBranch("feature/ratings-favourites", updated);
+      expect(getBranchEntry("feature/ratings-favourites")).toEqual(updated);
+    });
+
+    test("trims whitespace from branch name", () => {
+      registerBranch("  feature/spaces  ", exampleEntry);
+      expect(getBranchEntry("feature/spaces")).toEqual(exampleEntry);
+    });
+
+    test("ignores empty or whitespace-only branch names", () => {
+      registerBranch("", exampleEntry);
+      registerBranch("   ", exampleEntry);
+      // No file written since no valid branch was registered.
+      expect(fs.existsSync(registryPath)).toBe(false);
+    });
+  });
+
+  describe("getBranchEntry", () => {
+    test("returns the stored entry", () => {
+      registerBranch("feature/ratings-favourites", exampleEntry);
+      const entry = getBranchEntry("feature/ratings-favourites");
+      expect(entry).toEqual(exampleEntry);
+    });
+
+    test("returns undefined for a missing branch", () => {
+      expect(getBranchEntry("feature/nonexistent")).toBeUndefined();
+    });
+
+    test("returns undefined for empty branch name", () => {
+      expect(getBranchEntry("")).toBeUndefined();
+    });
+  });
+
+  describe("unregisterBranch", () => {
+    test("removes the entry from the registry", () => {
+      registerBranch("feature/ratings-favourites", exampleEntry);
+      unregisterBranch("feature/ratings-favourites");
+      expect(getBranchEntry("feature/ratings-favourites")).toBeUndefined();
+    });
+
+    test("does not remove other entries", () => {
+      registerBranch("feature/a", exampleEntry);
+      registerBranch("feature/b", { ...exampleEntry, sessionKey: "session:b" });
+      unregisterBranch("feature/a");
+      expect(getBranchEntry("feature/b")).toBeDefined();
+    });
+
+    test("is a no-op for a missing branch", () => {
+      // Should not throw.
+      expect(() => unregisterBranch("feature/nonexistent")).not.toThrow();
+    });
+  });
+
+  describe("listBranches", () => {
+    test("returns empty object when registry file does not exist", () => {
+      expect(listBranches()).toEqual({});
+    });
+
+    test("returns all entries when no checker is provided", () => {
+      registerBranch("feature/a", exampleEntry);
+      registerBranch("feature/b", { ...exampleEntry, sessionKey: "session:b" });
+      const result = listBranches();
+      expect(Object.keys(result)).toHaveLength(2);
+      expect(result["feature/a"]).toEqual(exampleEntry);
+      expect(result["feature/b"]).toBeDefined();
+    });
+
+    test("prunes stale entries when isSessionAlive returns false", () => {
+      const aliveEntry: BranchRegistryEntry = { ...exampleEntry, sessionKey: "session:alive" };
+      const deadEntry: BranchRegistryEntry = { ...exampleEntry, sessionKey: "session:dead" };
+      registerBranch("feature/alive", aliveEntry);
+      registerBranch("feature/dead", deadEntry);
+
+      const isSessionAlive = (key: string) => key === "session:alive";
+      const result = listBranches(isSessionAlive);
+
+      expect(result["feature/alive"]).toBeDefined();
+      expect(result["feature/dead"]).toBeUndefined();
+    });
+
+    test("persists pruned registry to disk after pruning", () => {
+      const aliveEntry: BranchRegistryEntry = { ...exampleEntry, sessionKey: "session:alive" };
+      const deadEntry: BranchRegistryEntry = { ...exampleEntry, sessionKey: "session:dead" };
+      registerBranch("feature/alive", aliveEntry);
+      registerBranch("feature/dead", deadEntry);
+
+      listBranches((key) => key === "session:alive");
+
+      const raw = JSON.parse(fs.readFileSync(registryPath, "utf8")) as Record<string, unknown>;
+      expect(raw["feature/dead"]).toBeUndefined();
+      expect(raw["feature/alive"]).toBeDefined();
+    });
+
+    test("does not write to disk when no entries are pruned", () => {
+      registerBranch("feature/alive", { ...exampleEntry, sessionKey: "session:alive" });
+      const statBefore = fs.statSync(registryPath);
+
+      // Small delay to ensure mtime would differ if written.
+      listBranches(() => true);
+
+      const statAfter = fs.statSync(registryPath);
+      expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
+    });
+
+    test("returns all entries when all sessions are alive", () => {
+      registerBranch("feature/a", exampleEntry);
+      registerBranch("feature/b", { ...exampleEntry, sessionKey: "session:b" });
+      const result = listBranches(() => true);
+      expect(Object.keys(result)).toHaveLength(2);
+    });
+
+    test("returns empty object when all sessions are dead", () => {
+      registerBranch("feature/a", exampleEntry);
+      registerBranch("feature/b", { ...exampleEntry, sessionKey: "session:b" });
+      const result = listBranches(() => false);
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/src/gateway/branch-registry.ts
+++ b/src/gateway/branch-registry.ts
@@ -1,0 +1,112 @@
+import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
+
+export type BranchRegistryEntry = {
+  /** Session key for the subagent that owns this branch. */
+  sessionKey: string;
+  /** GitHub PR number associated with this branch. */
+  prNumber?: number;
+  /** Repository identifier (e.g. "owner/repo"). */
+  repo?: string;
+  /** ISO 8601 timestamp when the entry was created. */
+  createdAt: string;
+  status: "watching";
+};
+
+export type BranchRegistry = Record<string, BranchRegistryEntry>;
+
+/**
+ * Resolves the path to the branch registry file.
+ * Override via OPENCLAW_BRANCH_REGISTRY_PATH env var.
+ * Default: ~/.openclaw/workspace/branches/_registry.json
+ */
+export function resolveBranchRegistryPath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.OPENCLAW_BRANCH_REGISTRY_PATH?.trim();
+  if (override) {
+    return path.resolve(override);
+  }
+  if (env.VITEST || env.NODE_ENV === "test") {
+    return path.join(
+      os.tmpdir(),
+      "openclaw-test-branch-registry",
+      String(process.pid),
+      "_registry.json",
+    );
+  }
+  return path.join(resolveStateDir(env), "workspace", "branches", "_registry.json");
+}
+
+function loadRegistry(env: NodeJS.ProcessEnv = process.env): BranchRegistry {
+  const raw = loadJsonFile(resolveBranchRegistryPath(env));
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  return raw as BranchRegistry;
+}
+
+function saveRegistry(registry: BranchRegistry, env: NodeJS.ProcessEnv = process.env): void {
+  saveJsonFile(resolveBranchRegistryPath(env), registry);
+}
+
+/** Register a branch → session mapping in the registry. */
+export function registerBranch(branch: string, entry: BranchRegistryEntry): void {
+  const trimmed = branch.trim();
+  if (!trimmed) {
+    return;
+  }
+  const registry = loadRegistry();
+  registry[trimmed] = entry;
+  saveRegistry(registry);
+}
+
+/** Remove a branch from the registry. No-op if the branch is not present. */
+export function unregisterBranch(branch: string): void {
+  const trimmed = branch.trim();
+  if (!trimmed) {
+    return;
+  }
+  const registry = loadRegistry();
+  if (!(trimmed in registry)) {
+    return;
+  }
+  delete registry[trimmed];
+  saveRegistry(registry);
+}
+
+/** Return the registry entry for a branch, or undefined if not found. */
+export function getBranchEntry(branch: string): BranchRegistryEntry | undefined {
+  const trimmed = branch.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const registry = loadRegistry();
+  return registry[trimmed];
+}
+
+/**
+ * Return all branches in the registry.
+ * When `isSessionAlive` is provided, stale entries (whose session is no longer
+ * alive) are pruned on read — removed from the file and excluded from the result.
+ */
+export function listBranches(isSessionAlive?: (sessionKey: string) => boolean): BranchRegistry {
+  const registry = loadRegistry();
+  if (!isSessionAlive) {
+    return registry;
+  }
+  const stale: string[] = [];
+  for (const [branch, entry] of Object.entries(registry)) {
+    if (!isSessionAlive(entry.sessionKey)) {
+      stale.push(branch);
+    }
+  }
+  if (stale.length === 0) {
+    return registry;
+  }
+  for (const branch of stale) {
+    delete registry[branch];
+  }
+  saveRegistry(registry);
+  return registry;
+}

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -290,6 +290,31 @@ describe("gateway hooks helpers", () => {
     ).toBe("slack:channel:c123");
   });
 
+  test("normalizeAgentPayload preserves dispatch object", () => {
+    const ok = normalizeAgentPayload({
+      message: "hello",
+      dispatch: { branch: "feature/x", registryHit: true },
+    });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) {
+      expect(ok.value.dispatch).toEqual({ branch: "feature/x", registryHit: true });
+    }
+  });
+
+  test("normalizeAgentPayload omits dispatch for non-objects", () => {
+    const withString = normalizeAgentPayload({ message: "hello", dispatch: "bad" });
+    expect(withString.ok && withString.value.dispatch).toBeUndefined();
+
+    const withNull = normalizeAgentPayload({ message: "hello", dispatch: null });
+    expect(withNull.ok && withNull.value.dispatch).toBeUndefined();
+
+    const withArray = normalizeAgentPayload({ message: "hello", dispatch: [1, 2] });
+    expect(withArray.ok && withArray.value.dispatch).toBeUndefined();
+
+    const withNone = normalizeAgentPayload({ message: "hello" });
+    expect(withNone.ok && withNone.value.dispatch).toBeUndefined();
+  });
+
   test("normalizeHookDispatchSessionKey preserves non-target agent scoped keys", () => {
     expect(
       normalizeHookDispatchSessionKey({

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -233,6 +233,8 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  /** Optional metadata forwarded by the webhook proxy (e.g. branch, registry hits). */
+  dispatch?: Record<string, unknown>;
 };
 
 export type HookAgentDispatchPayload = Omit<HookAgentPayload, "sessionKey"> & {
@@ -415,6 +417,11 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const dispatchRaw = payload.dispatch;
+  const dispatch =
+    typeof dispatchRaw === "object" && dispatchRaw !== null && !Array.isArray(dispatchRaw)
+      ? (dispatchRaw as Record<string, unknown>)
+      : undefined;
   return {
     ok: true,
     value: {
@@ -430,6 +437,7 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
       model,
       thinking,
       timeoutSeconds,
+      dispatch,
     },
   };
 }

--- a/src/gateway/server/hooks.test.ts
+++ b/src/gateway/server/hooks.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock modules before importing the module under test.
+vi.mock("../../routing/session-key.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    isSubagentSessionKey: vi.fn(),
+  };
+});
+
+vi.mock("../../agents/subagent-registry.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    initSubagentRegistry: vi.fn(),
+    isSubagentSessionRunActive: vi.fn(),
+  };
+});
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: vi.fn(),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveMainSessionKeyFromConfig: vi.fn(() => "signal:direct:+14168999152"),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("../../cron/isolated-agent.js", () => ({
+  runCronIsolatedAgentTurn: vi.fn(async () => ({
+    status: "ok",
+    summary: "done",
+    delivered: true,
+  })),
+}));
+
+import {
+  initSubagentRegistry,
+  isSubagentSessionRunActive,
+} from "../../agents/subagent-registry.js";
+import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+// Import after mocks are set up.
+import { isSubagentSessionKey } from "../../routing/session-key.js";
+import type { HookAgentDispatchPayload } from "../hooks.js";
+
+describe("dispatchAgentHook session-aware routing", () => {
+  const mockedIsSubagentSessionKey = vi.mocked(isSubagentSessionKey);
+  const mockedIsSubagentSessionRunActive = vi.mocked(isSubagentSessionRunActive);
+  const mockedInitSubagentRegistry = vi.mocked(initSubagentRegistry);
+  const mockedEnqueueSystemEvent = vi.mocked(enqueueSystemEvent);
+  const mockedRequestHeartbeatNow = vi.mocked(requestHeartbeatNow);
+  const mockedRunCronIsolatedAgentTurn = vi.mocked(runCronIsolatedAgentTurn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Helper: call dispatchAgentHook by going through `createGatewayHooksRequestHandler`
+   * and intercepting the `createHooksRequestHandler` call.
+   *
+   * Since `dispatchAgentHook` is a closure, we hook into `createHooksRequestHandler`
+   * to capture it.
+   */
+  async function callDispatchAgentHook(
+    payload: HookAgentDispatchPayload,
+  ): Promise<{ runId: string }> {
+    // We need to spy on createHooksRequestHandler to capture the dispatchAgentHook closure.
+    const serverHttpModule = await import("../server-http.js");
+    let capturedDispatchFn: ((value: HookAgentDispatchPayload) => string) | undefined;
+
+    const originalCreate = serverHttpModule.createHooksRequestHandler;
+    vi.spyOn(serverHttpModule, "createHooksRequestHandler").mockImplementation((opts: never) => {
+      const typedOpts = opts as { dispatchAgentHook: (value: HookAgentDispatchPayload) => string };
+      capturedDispatchFn = typedOpts.dispatchAgentHook;
+      return originalCreate(opts);
+    });
+
+    const { createGatewayHooksRequestHandler } = await import("./hooks.js");
+
+    createGatewayHooksRequestHandler({
+      deps: {} as never,
+      getHooksConfig: () => ({
+        basePath: "/hooks",
+        token: "test-token",
+        maxBodyBytes: 256 * 1024,
+        mappings: [],
+        agentPolicy: {
+          defaultAgentId: "main",
+          knownAgentIds: new Set(["main"]),
+        },
+        sessionPolicy: {
+          allowRequestSessionKey: true,
+        },
+      }),
+      getClientIpConfig: () => ({}),
+      bindHost: "127.0.0.1",
+      port: 18789,
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    });
+
+    if (!capturedDispatchFn) {
+      throw new Error("Failed to capture dispatchAgentHook from closure");
+    }
+
+    const runId = capturedDispatchFn(payload);
+    return { runId };
+  }
+
+  const basePayload: HookAgentDispatchPayload = {
+    message: "PR #42 was merged",
+    name: "GitHub",
+    agentId: "main",
+    wakeMode: "now",
+    sessionKey: "subagent:pm-abc123",
+    deliver: true,
+    channel: "last",
+  };
+
+  test("injects system event for alive subagent session", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(true);
+    mockedIsSubagentSessionRunActive.mockReturnValue(true);
+
+    const { runId } = await callDispatchAgentHook(basePayload);
+
+    // Should have initialized registry and checked liveness.
+    expect(mockedInitSubagentRegistry).toHaveBeenCalled();
+    expect(mockedIsSubagentSessionRunActive).toHaveBeenCalledWith("subagent:pm-abc123");
+
+    // Should inject system event with correct session key.
+    expect(mockedEnqueueSystemEvent).toHaveBeenCalledWith("[Hook: GitHub] PR #42 was merged", {
+      sessionKey: "subagent:pm-abc123",
+    });
+
+    // Should wake the specific session.
+    expect(mockedRequestHeartbeatNow).toHaveBeenCalledWith({
+      reason: "hook:GitHub",
+      sessionKey: "subagent:pm-abc123",
+    });
+
+    // Should return a UUID.
+    expect(runId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+    // Should NOT create an isolated cron turn.
+    expect(mockedRunCronIsolatedAgentTurn).not.toHaveBeenCalled();
+  });
+
+  test("includes dispatch metadata in system event text", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(true);
+    mockedIsSubagentSessionRunActive.mockReturnValue(true);
+
+    const dispatch = { branch: "feature/ratings", registryHit: true, contextDocPath: "/tmp/x.md" };
+    await callDispatchAgentHook({ ...basePayload, dispatch });
+
+    const eventText = mockedEnqueueSystemEvent.mock.calls[0]?.[0];
+    expect(eventText).toContain("[Hook: GitHub]");
+    expect(eventText).toContain("PR #42 was merged");
+    expect(eventText).toContain("[Dispatch metadata:");
+    expect(eventText).toContain('"branch":"feature/ratings"');
+    expect(eventText).toContain('"registryHit":true');
+  });
+
+  test("falls back to main session for dead subagent", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(true);
+    mockedIsSubagentSessionRunActive.mockReturnValue(false);
+
+    await callDispatchAgentHook(basePayload);
+
+    // Should check liveness.
+    expect(mockedInitSubagentRegistry).toHaveBeenCalled();
+    expect(mockedIsSubagentSessionRunActive).toHaveBeenCalledWith("subagent:pm-abc123");
+
+    // Should NOT inject a system event for the subagent.
+    // Instead it creates an isolated turn (which calls runCronIsolatedAgentTurn).
+    expect(mockedRunCronIsolatedAgentTurn).toHaveBeenCalled();
+
+    // The isolated turn should use the main session key (fallback).
+    const callArgs = mockedRunCronIsolatedAgentTurn.mock.calls[0]?.[0] as {
+      sessionKey: string;
+    };
+    expect(callArgs.sessionKey).toBe("signal:direct:+14168999152");
+  });
+
+  test("uses existing behavior for non-subagent session keys", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(false);
+
+    await callDispatchAgentHook({
+      ...basePayload,
+      sessionKey: "hook:abc123",
+    });
+
+    // Should not check subagent registry.
+    expect(mockedInitSubagentRegistry).not.toHaveBeenCalled();
+    expect(mockedIsSubagentSessionRunActive).not.toHaveBeenCalled();
+
+    // Should create an isolated cron turn.
+    expect(mockedRunCronIsolatedAgentTurn).toHaveBeenCalled();
+
+    // Should use the original session key.
+    const callArgs = mockedRunCronIsolatedAgentTurn.mock.calls[0]?.[0] as {
+      sessionKey: string;
+    };
+    expect(callArgs.sessionKey).toBe("hook:abc123");
+  });
+});

--- a/src/gateway/server/hooks.test.ts
+++ b/src/gateway/server/hooks.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 // Mock modules before importing the module under test.
+vi.mock("../branch-registry.js", () => ({
+  registerBranch: vi.fn(),
+  unregisterBranch: vi.fn(),
+}));
+
 vi.mock("../../routing/session-key.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -51,6 +56,7 @@ import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 // Import after mocks are set up.
 import { isSubagentSessionKey } from "../../routing/session-key.js";
+import { registerBranch, unregisterBranch } from "../branch-registry.js";
 import type { HookAgentDispatchPayload } from "../hooks.js";
 
 describe("dispatchAgentHook session-aware routing", () => {
@@ -60,6 +66,8 @@ describe("dispatchAgentHook session-aware routing", () => {
   const mockedEnqueueSystemEvent = vi.mocked(enqueueSystemEvent);
   const mockedRequestHeartbeatNow = vi.mocked(requestHeartbeatNow);
   const mockedRunCronIsolatedAgentTurn = vi.mocked(runCronIsolatedAgentTurn);
+  const mockedRegisterBranch = vi.mocked(registerBranch);
+  const mockedUnregisterBranch = vi.mocked(unregisterBranch);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -215,5 +223,85 @@ describe("dispatchAgentHook session-aware routing", () => {
       sessionKey: string;
     };
     expect(callArgs.sessionKey).toBe("hook:abc123");
+  });
+
+  test("registers branch in registry after isolated turn spawned with branch in dispatch", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(false);
+    mockedRunCronIsolatedAgentTurn.mockResolvedValueOnce({
+      status: "ok",
+      summary: "done",
+      delivered: true,
+      sessionKey: "hook:abc123:run:xyz",
+    });
+
+    const dispatch = {
+      branch: "feature/ratings-favourites",
+      prNumber: 56,
+      repo: "yoiksoft/yoik.me",
+    };
+    await callDispatchAgentHook({ ...basePayload, sessionKey: "hook:abc123", dispatch });
+
+    expect(mockedRegisterBranch).toHaveBeenCalledWith("feature/ratings-favourites", {
+      sessionKey: "hook:abc123:run:xyz",
+      prNumber: 56,
+      repo: "yoiksoft/yoik.me",
+      createdAt: expect.any(String),
+      status: "watching",
+    });
+  });
+
+  test("does not register branch when result has no sessionKey", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(false);
+    // Default mock returns no sessionKey.
+
+    const dispatch = { branch: "feature/ratings-favourites" };
+    await callDispatchAgentHook({ ...basePayload, dispatch });
+
+    expect(mockedRegisterBranch).not.toHaveBeenCalled();
+  });
+
+  test("does not register branch when dispatch has no branch", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(false);
+    mockedRunCronIsolatedAgentTurn.mockResolvedValueOnce({
+      status: "ok",
+      summary: "done",
+      delivered: true,
+      sessionKey: "hook:abc123:run:xyz",
+    });
+
+    await callDispatchAgentHook({ ...basePayload, sessionKey: "hook:abc123" });
+
+    expect(mockedRegisterBranch).not.toHaveBeenCalled();
+  });
+
+  test("unregisters branch from registry when dead session has branch in dispatch", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(true);
+    mockedIsSubagentSessionRunActive.mockReturnValue(false);
+
+    const dispatch = { branch: "feature/ratings", prNumber: 42, repo: "yoiksoft/yoik.me" };
+    await callDispatchAgentHook({ ...basePayload, dispatch });
+
+    expect(mockedUnregisterBranch).toHaveBeenCalledWith("feature/ratings");
+  });
+
+  test("does not call unregisterBranch when dead session has no branch in dispatch", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(true);
+    mockedIsSubagentSessionRunActive.mockReturnValue(false);
+
+    // basePayload has no dispatch field.
+    await callDispatchAgentHook(basePayload);
+
+    expect(mockedUnregisterBranch).not.toHaveBeenCalled();
+  });
+
+  test("does not touch registry when alive subagent handles hook directly", async () => {
+    mockedIsSubagentSessionKey.mockReturnValue(true);
+    mockedIsSubagentSessionRunActive.mockReturnValue(true);
+
+    const dispatch = { branch: "feature/ratings", prNumber: 42 };
+    await callDispatchAgentHook({ ...basePayload, dispatch });
+
+    expect(mockedRegisterBranch).not.toHaveBeenCalled();
+    expect(mockedUnregisterBranch).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+  initSubagentRegistry,
+  isSubagentSessionRunActive,
+} from "../../agents/subagent-registry.js";
 import type { CliDeps } from "../../cli/deps.js";
 import { loadConfig, type OpenClawConfig } from "../../config/config.js";
 import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
@@ -7,6 +11,7 @@ import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import {
   normalizeHookDispatchSessionKey,
   type HookAgentDispatchPayload,
@@ -42,11 +47,28 @@ export function createGatewayHooksRequestHandler(params: {
   };
 
   const dispatchAgentHook = (value: HookAgentDispatchPayload) => {
-    const sessionKey = normalizeHookDispatchSessionKey({
+    let sessionKey = normalizeHookDispatchSessionKey({
       sessionKey: value.sessionKey,
       targetAgentId: value.agentId,
     });
     const mainSessionKey = resolveMainSessionKeyFromConfig();
+
+    // Session-aware routing: inject into live subagent sessions directly.
+    if (isSubagentSessionKey(sessionKey)) {
+      initSubagentRegistry();
+      if (isSubagentSessionRunActive(sessionKey)) {
+        const dispatchContext = value.dispatch
+          ? `\n\n[Dispatch metadata: ${JSON.stringify(value.dispatch)}]`
+          : "";
+        const eventText = `[Hook: ${value.name}] ${value.message}${dispatchContext}`;
+        enqueueSystemEvent(eventText, { sessionKey });
+        requestHeartbeatNow({ reason: `hook:${value.name}`, sessionKey });
+        return randomUUID();
+      }
+      // Subagent session is dead — fall back to main session.
+      sessionKey = mainSessionKey;
+    }
+
     const jobId = randomUUID();
     const now = Date.now();
     const job: CronJob = {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -12,6 +12,7 @@ import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
+import { registerBranch, unregisterBranch } from "../branch-registry.js";
 import {
   normalizeHookDispatchSessionKey,
   type HookAgentDispatchPayload,
@@ -65,7 +66,17 @@ export function createGatewayHooksRequestHandler(params: {
         requestHeartbeatNow({ reason: `hook:${value.name}`, sessionKey });
         return randomUUID();
       }
-      // Subagent session is dead — fall back to main session.
+      // Subagent session is dead — clean up registry entry if a branch was being tracked.
+      const deadBranch =
+        typeof value.dispatch?.branch === "string" ? value.dispatch.branch.trim() : "";
+      if (deadBranch) {
+        try {
+          unregisterBranch(deadBranch);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+      // Fall back to main session.
       sessionKey = mainSessionKey;
     }
 
@@ -108,6 +119,28 @@ export function createGatewayHooksRequestHandler(params: {
           lane: "cron",
           deliveryContract: "shared",
         });
+        // Register branch in the registry when dispatch includes a branch.
+        const spawnBranch =
+          typeof value.dispatch?.branch === "string" ? value.dispatch.branch.trim() : "";
+        if (spawnBranch && result.sessionKey) {
+          try {
+            registerBranch(spawnBranch, {
+              sessionKey: result.sessionKey,
+              prNumber:
+                typeof value.dispatch?.prNumber === "number"
+                  ? Math.floor(value.dispatch.prNumber)
+                  : undefined,
+              repo:
+                typeof value.dispatch?.repo === "string" && value.dispatch.repo.trim()
+                  ? value.dispatch.repo.trim()
+                  : undefined,
+              createdAt: new Date().toISOString(),
+              status: "watching",
+            });
+          } catch {
+            // best-effort registry write
+          }
+        }
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;


### PR DESCRIPTION
Routes webhook events to existing live subagent sessions instead of always creating new isolated sessions.

## Changes

- **Hook payload**: Added `dispatch` field to `HookAgentPayload` type and extraction in `normalizeAgentPayload()`
- **Session-aware routing**: `dispatchAgentHook` now checks if the target session key is a live subagent. If alive, injects the message via `enqueueSystemEvent` + heartbeat wake. If dead, falls back to isolated turn targeting main session.
- **Tests**: Coverage for dispatch passthrough, live session injection, dead session fallback, and non-subagent key behavior (23 tests across 2 files).

## How it works

1. Webhook proxy sends `sessionKey` targeting a subagent (e.g. `subagent:pm-abc123`)
2. `dispatchAgentHook` checks `isSubagentSessionKey(sessionKey)`
3. If subagent: initializes registry, checks `isSubagentSessionRunActive(sessionKey)`
4. If alive: injects message + dispatch metadata as system event, wakes the session
5. If dead: falls back to main session key, creates isolated turn as before
6. If not a subagent key: existing behavior unchanged

## Test summary

- `normalizeAgentPayload` preserves dispatch objects, omits non-objects
- `dispatchAgentHook` injects system event for alive subagent sessions
- `dispatchAgentHook` falls back to main session for dead subagents
- `dispatchAgentHook` uses existing behavior for non-subagent keys
- Dispatch metadata included in system event text when present